### PR TITLE
Get active client subscription

### DIFF
--- a/crm/models.py
+++ b/crm/models.py
@@ -623,7 +623,7 @@ class ClientManager(TenantManagerMixin, models.Manager):
     def with_active_subscription_to_event(self, event: Event):
         cs = (
             ClientSubscriptions.objects
-            .active_subscriptions(event)
+            .active_subscriptions_to_event(event)
             .order_by('client_id')
             .distinct('client_id')
             .values_list('client_id', flat=True)
@@ -734,7 +734,7 @@ class Client(CompanyObjectModel):
 
 
 class ClientSubscriptionQuerySet(TenantQuerySet):
-    def active_subscriptions(self, event: Event):
+    def active_subscriptions_to_event(self, event: Event):
         """Get all active subscriptions for selected event"""
         return self.filter(
             subscription__event_class=event.event_class,
@@ -748,11 +748,11 @@ class ClientSubscriptionsManager(
     ScrmTenantManagerMixin,
     BaseManager.from_queryset(ClientSubscriptionQuerySet)
 ):
-    def active_subscriptions(self, event: Event):
-        return self.get_queryset().active_subscriptions(event)
+    def active_subscriptions_to_event(self, event: Event):
+        return self.get_queryset().active_subscriptions_to_event(event)
 
     def extend_by_cancellation(self, cancelled_event: Event):
-        for subscription in self.active_subscriptions(cancelled_event):
+        for subscription in self.active_subscriptions_to_event(cancelled_event):
             subscription.extend_by_cancellation(cancelled_event)
 
     def revoke_extending(self, activated_event: Event):

--- a/crm/models.py
+++ b/crm/models.py
@@ -679,17 +679,25 @@ class Client(CompanyObjectModel):
         return self.company.vk_access_token
 
     def update_balance(self, top_up_amount, skip_notification: bool = False):
-        '''
+        """
+        :param top_up_amount: Amount of added or removed from balance
         :param skip_notification: Prevent double notification send if buy sub
-        '''
+        """
         self.balance = self.balance + decimal.Decimal(top_up_amount)
         self.save()
         if not skip_notification:
             from google_tasks.tasks import enqueue
             enqueue('notify_client_balance', self.id)
 
-    def add_balance_in_history(self, top_up_amount, reason, skip_notification: bool = False):
+    def add_balance_in_history(
+        self,
+        top_up_amount: int,
+        reason: str,
+        skip_notification: bool = False
+    ):
         """
+        :param top_up_amount: Amount of added or removed from balance
+        :param reason: Reason of client balance modification
         :param skip_notification: Prevent double notification send if buy sub
         """
         with transaction.atomic():

--- a/crm/tests/test_models/test_client_subscription.py
+++ b/crm/tests/test_models/test_client_subscription.py
@@ -331,7 +331,7 @@ def test_extend_by_cancellation_with_future_date(
     )
 
 
-def test_qs_active_subscriptions(
+def test_qs_active_subscriptions_to_event(
     subscriptions_type_factory,
     client_subscription_factory,
     event_factory
@@ -382,19 +382,19 @@ def test_qs_active_subscriptions(
         models.ClientSubscriptions
         .objects
         .get_queryset()
-        .active_subscriptions(event),
+        .active_subscriptions_to_event(event),
 
         contains_inanyorder(*active_subs)
     )
 
 
-def test_manager_active_subscriptions(
+def test_manager_active_subscriptions_to_event(
     mocker: MockFixture
 ):
     mock = mocker.patch(
-        'crm.models.ClientSubscriptionQuerySet.active_subscriptions')
+        'crm.models.ClientSubscriptionQuerySet.active_subscriptions_to_event')
 
-    models.ClientSubscriptions.objects.active_subscriptions(mocker.ANY)
+    models.ClientSubscriptions.objects.active_subscriptions_to_event(mocker.ANY)
 
     mock.assert_called_once_with(mocker.ANY)
 

--- a/crm/tests/test_models/test_client_subscription.py
+++ b/crm/tests/test_models/test_client_subscription.py
@@ -388,6 +388,144 @@ def test_qs_active_subscriptions_to_event(
     )
 
 
+def test_qs_active_subscriptions_to_date(
+    company_factory,
+    subscriptions_type_factory,
+    client_subscription_factory,
+    event_factory,
+    client_factory
+):
+    company = company_factory()
+    events = event_factory.create_batch(
+        3,
+        company=company,
+        date=date(2019, 2, 25),
+        event_class__date_from=date(2019, 1, 1)
+    )
+    subs = []
+    for event in events:
+        subs.append(subscriptions_type_factory(
+            company=company,
+            duration=1,
+            duration_type=GRANULARITY.MONTH,
+            rounding=False,
+            event_class__events=event.event_class,
+            visit_limit=1
+        ))
+
+    client = client_factory(
+        company=company
+    )
+    cs1 = client_subscription_factory(
+        client=client,
+        company=company,
+        subscription=subs[0],
+        start_date=date(2019, 2, 1),
+        visits_left=subs[0].visit_limit
+    )
+    cs2 = client_subscription_factory(
+        client=client,
+        company=company,
+        subscription=subs[1],
+        start_date=date(2019, 2, 10),
+        visits_left=subs[1].visit_limit
+    )
+    cs3 = client_subscription_factory(
+        client=client,
+        company=company,
+        subscription=subs[2],
+        start_date=date(2019, 3, 1),
+        visits_left=subs[2].visit_limit
+    )
+    client.mark_visit(events[0], cs1)
+
+    assert_that(
+        models.ClientSubscriptions
+            .objects
+            .get_queryset()
+            .active_subscriptions_to_date(date(2019, 2, 25)),
+
+        contains_inanyorder(cs1, cs2)
+    )
+
+    assert_that(
+        models.ClientSubscriptions
+        .objects
+        .get_queryset()
+        .active_subscriptions_to_date(date(2019, 2, 27)),
+
+        # cs1 don't appear in result, as at 27.02.2019 it is completely used
+        contains_inanyorder(cs2)
+    )
+
+    assert_that(
+        models.ClientSubscriptions
+            .objects
+            .get_queryset()
+            .active_subscriptions_to_date(date(2019, 3, 2)),
+
+        contains_inanyorder(cs2, cs3)
+    )
+
+
+def test_qs_active_subscriptions(
+    subscriptions_type_factory,
+    client_subscription_factory,
+    event_factory,
+):
+    event = event_factory(
+        date=date(2019, 2, 25),
+        event_class__date_from=date(2019, 1, 1)
+    )
+    subs = subscriptions_type_factory(
+        company=event.company,
+        duration=1,
+        duration_type=GRANULARITY.MONTH,
+        rounding=False,
+        event_class__events=event.event_class
+    )
+
+    active_subs = client_subscription_factory.create_batch(
+        3,
+        company=event.company,
+        subscription=subs,
+        purchase_date=date(2019, 2, 25),
+        start_date=date(2019, 2, 25)
+    )
+    # outdated_sub
+    client_subscription_factory(
+        company=event.company,
+        subscription=subs,
+        purchase_date=date(2019, 1, 1),
+        start_date=date(2019, 1, 1)
+    )
+    # future_sub
+    client_subscription_factory(
+        company=event.company,
+        subscription=subs,
+        purchase_date=date(2019, 3, 1),
+        start_date=date(2019, 3, 1)
+    )
+    # empty_sub
+    client_subscription_factory(
+        company=event.company,
+        subscription=subs,
+        purchase_date=date(2019, 2, 25),
+        start_date=date(2019, 2, 25),
+        visits_left=0
+    )
+
+    with freeze_time(date(2019, 2, 26)):
+        assert_that(
+            models.ClientSubscriptions
+            .objects
+            .get_queryset()
+            .active_subscriptions(),
+
+            contains_inanyorder(*active_subs)
+        )
+
+
 def test_manager_active_subscriptions_to_event(
     mocker: MockFixture
 ):
@@ -397,6 +535,28 @@ def test_manager_active_subscriptions_to_event(
     models.ClientSubscriptions.objects.active_subscriptions_to_event(mocker.ANY)
 
     mock.assert_called_once_with(mocker.ANY)
+
+
+def test_manager_active_subscriptions_to_date(
+    mocker: MockFixture
+):
+    mock = mocker.patch(
+        'crm.models.ClientSubscriptionQuerySet.active_subscriptions_to_date')
+
+    models.ClientSubscriptions.objects.active_subscriptions_to_date(mocker.ANY)
+
+    mock.assert_called_once_with(mocker.ANY)
+
+
+def test_manager_active_subscriptions(
+    mocker: MockFixture
+):
+    mock = mocker.patch(
+        'crm.models.ClientSubscriptionQuerySet.active_subscriptions')
+
+    models.ClientSubscriptions.objects.active_subscriptions()
+
+    mock.assert_called_once()
 
 
 def test_manager_extend_by_cancellation(

--- a/crm/views/manager/event_class.py
+++ b/crm/views/manager/event_class.py
@@ -94,7 +94,7 @@ class EventByDate(
         result = {}
         for client in clients_qs:
             client_subscriptions = result.setdefault(client, [])
-            subs = client.clientsubscriptions_set.active_subscriptions(
+            subs = client.clientsubscriptions_set.active_subscriptions_to_event(
                 self.object
             )
             for sub in subs:
@@ -573,7 +573,7 @@ class DoScan(
         event = self.get_object()
         subscription = (
             ClientSubscriptions.objects
-            .active_subscriptions(event)
+            .active_subscriptions_to_event(event)
             .filter(client=client)
             .order_by('purchase_date')
             .first()


### PR DESCRIPTION
Два метода получения активных подписок - на дату, и на сегодня.
**На сегодня** - упрощенный вариант, так как не надо вычислять какие были посещения на дату и смотрим только на сколько осталось визитов.
**На дату** - вариант с расчетом а сколько визитов оставалось на дату, исходя из посещения