### PR TITLE
Add logic for overpasted events

### DIFF
--- a/crm/models.py
+++ b/crm/models.py
@@ -845,6 +845,8 @@ class ClientSubscriptionQuerySet(TenantQuerySet):
             visits_left__gt=0
         ) | self.filter(
             visits_left=1,
+            start_date=today,
+            end_date=today,
             subscription__one_time=True,
         )
 

--- a/crm/templates/crm/manager/_client_list_item_buttons.html
+++ b/crm/templates/crm/manager/_client_list_item_buttons.html
@@ -1,14 +1,31 @@
 {% if not client.deleted %}
-  {% for sub in active_sub %}
-    {% if not max_start_subscription_date  or sub.start_date <= max_start_subscription_date%}
-      {% include 'crm/manager/_client_list_item_button.html' %}
-      {% if active_sub|length > 1 %}
-        {% if not forloop.last %}
-          <div class="greyline"></div>
+  {% if event and event.is_overpast %}
+    {% with action=subscriptions|length|yesno:"mark,new_subscription" %}
+      {% for sub in subscriptions %}
+        {% if not max_start_subscription_date  or sub.start_date <= max_start_subscription_date%}
+          {% include 'crm/manager/_client_list_item_button.html' %}
+          {% if subscriptions|length > 1 %}
+            {% if not forloop.last %}
+              <div class="greyline"></div>
+            {% endif %}
+          {% endif %}
         {% endif %}
-      {% endif %}
-    {% endif %}
-  {% empty %}
-    {% include 'crm/manager/_client_list_item_button.html' %}
-  {% endfor %}
+      {% endfor %}
+    {% endwith %}
+  {% else %}
+    {% with action=active_sub|length|yesno:"mark,new_subscription" %}
+      {% for sub in active_sub %}
+        {% if not max_start_subscription_date  or sub.start_date <= max_start_subscription_date%}
+          {% include 'crm/manager/_client_list_item_button.html' %}
+          {% if active_sub|length > 1 %}
+            {% if not forloop.last %}
+              <div class="greyline"></div>
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% empty %}
+        {% include 'crm/manager/_client_list_item_button.html' %}
+      {% endfor %}
+    {% endwith %}
+  {% endif %}
 {% endif %}

--- a/crm/templates/crm/manager/_client_list_item_sub_end-date.html
+++ b/crm/templates/crm/manager/_client_list_item_sub_end-date.html
@@ -1,10 +1,24 @@
-{% for sub in active_sub %}
-  <span class="date">{{ sub.end_date|date:"SHORT_DATE_FORMAT" }}</span>
-  {% if active_sub|length > 1 %}
-    {% if not forloop.last %}
-      <div class="greyline"></div>
+{% if event and event.is_overpast %}
+  {% for sub in subscriptions %}
+    <span class="date">{{ sub.end_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if subscriptions|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
     {% endif %}
-  {% endif %}
-{% empty %}
-  &nbsp;
-{% endfor %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+
+{% else %}
+  {% for sub in active_sub %}
+    <span class="date">{{ sub.end_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if active_sub|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
+    {% endif %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+{% endif %}

--- a/crm/templates/crm/manager/_client_list_item_sub_last-date.html
+++ b/crm/templates/crm/manager/_client_list_item_sub_last-date.html
@@ -1,16 +1,29 @@
-{% for sub in active_sub %}
-  {% with  last_visited_event=sub.last_visited_event %}
-      <span class="date">
-        {{ last_visited_event.date|date:"SHORT_DATE_FORMAT" }}&nbsp;
-      </span>
-        {% if not forloop.last %}
-          <div class="greyline"></div>
-        {% endif %}
-  {% endwith %}
-{% empty %}
-  {% if last_sub %}
-    {% with  last_visited_event=sub.last_visited_event %}
-      {{ last_visited_event.date|date:"SHORT_DATE_FORMAT" }}&nbsp;
+{% if event and event.is_overpast %}
+  {% for sub in subscriptions %}
+    {% with last_visited_event=sub.last_visited_event %}
+        <span class="date">
+          {{ last_visited_event.date|date:"SHORT_DATE_FORMAT" }}&nbsp;
+        </span>
+          {% if not forloop.last %}
+            <div class="greyline"></div>
+          {% endif %}
     {% endwith %}
-  {% endif %}
-{% endfor %}
+  {% endfor %}
+{% else %}
+  {% for sub in active_sub %}
+    {% with  last_visited_event=sub.last_visited_event %}
+        <span class="date">
+          {{ last_visited_event.date|date:"SHORT_DATE_FORMAT" }}&nbsp;
+        </span>
+          {% if not forloop.last %}
+            <div class="greyline"></div>
+          {% endif %}
+    {% endwith %}
+  {% empty %}
+    {% if last_sub %}
+      {% with  last_visited_event=sub.last_visited_event %}
+        {{ last_visited_event.date|date:"SHORT_DATE_FORMAT" }}&nbsp;
+      {% endwith %}
+    {% endif %}
+  {% endfor %}
+{% endif %}

--- a/crm/templates/crm/manager/_client_list_item_sub_purchase-date.html
+++ b/crm/templates/crm/manager/_client_list_item_sub_purchase-date.html
@@ -1,12 +1,59 @@
-{% for sub in active_sub %}
-  {{ sub.purchase_date|date:"SHORT_DATE_FORMAT" }}
-  <br/>
-  <small>{{ sub.sold_by|default_if_none:'' }}</small>
-  {% if active_sub|length > 1 %}
-    {% if not forloop.last %}
-      <div class="greyline"></div>
+{% if event and event.is_overpast %}
+  {% for sub in subscriptions %}
+    {% if not sub.sold_by %}
+      {% if subscriptions|length > 1 %}
+        {% if not forloop.last %}
+          <small>&nbsp;</small><br>
+        {% endif %}
+      {% endif %}
     {% endif %}
-  {% endif %}
-{% empty %}
-  &nbsp;
-{% endfor %}
+    <span class="date">{{ sub.purchase_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if sub.sold_by %}
+      <br/>
+    <small>{{ sub.sold_by|default_if_none:'&nbsp;' }}</small>
+    {% else %}
+      {% if subscriptions|length > 1 %}
+        {% if forloop.last %}
+          <br/>
+          <small>&nbsp;</small>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    {% if subscriptions|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
+    {% endif %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+{% else %}
+  {% for sub in active_sub %}
+    {% if not sub.sold_by %}
+      {% if active_sub|length > 1 %}
+        {% if not forloop.last %}
+          <small>&nbsp;</small><br>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    <span class="date">{{ sub.purchase_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if sub.sold_by %}
+    <br/>
+    <small>{{ sub.sold_by|default_if_none:'&nbsp;' }}</small>
+    {% else %}
+      {% if active_sub|length > 1 %}
+        {% if forloop.last %}
+          <br/>
+          <small>&nbsp;</small>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+    {% if active_sub|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
+    {% endif %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+{% endif %}

--- a/crm/templates/crm/manager/_client_list_item_sub_start-date.html
+++ b/crm/templates/crm/manager/_client_list_item_sub_start-date.html
@@ -1,10 +1,23 @@
-{% for sub in active_sub %}
-  <span class="date">{{ sub.start_date|date:"SHORT_DATE_FORMAT" }}</span>
-  {% if active_sub|length > 1 %}
-    {% if not forloop.last %}
-      <div class="greyline"></div>
+{% if event and event.is_overpast %}
+  {% for sub in subscriptions %}
+    <span class="date">{{ sub.start_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if subscriptions|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
     {% endif %}
-  {% endif %}
-{% empty %}
-  &nbsp;
-{% endfor %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+{% else %}
+  {% for sub in active_sub %}
+    <span class="date">{{ sub.start_date|date:"SHORT_DATE_FORMAT" }}</span>
+    {% if active_sub|length > 1 %}
+      {% if not forloop.last %}
+        <div class="greyline"></div>
+      {% endif %}
+    {% endif %}
+  {% empty %}
+    &nbsp;
+  {% endfor %}
+{% endif %}

--- a/crm/templates/crm/manager/_client_list_item_subscription.html
+++ b/crm/templates/crm/manager/_client_list_item_subscription.html
@@ -1,19 +1,8 @@
 {% load html_helper %}
 
-{% if active_sub|length == 1 %}
-  {% with active_sub.first as sub %}
-    {% if sub.is_expiring %}
-      <span class="yellow">{{ sub.subscription.name }}</span>
-    {% else %}
-      {{ sub.subscription.name }}
-    {% endif %}
-    <br/>
-    <small>Доступно посещений: {{ sub.visits_left }} из
-      {{ sub.visits_on_by_time }}</small>
-  {% endwith %}
-{% elif active_sub|length > 1 %}
-  <form class="subscription_select">
-    {% for sub in active_sub %}
+{% if event and event.is_overpast %}
+  {% if subscriptions|length == 1 %}
+    {% with subscriptions.0 as sub %}
       {% if sub.is_expiring %}
         <span class="yellow">{{ sub.subscription.name }}</span>
       {% else %}
@@ -22,25 +11,83 @@
       <br/>
       <small>Доступно посещений: {{ sub.visits_left }} из
         {{ sub.visits_on_by_time }}</small>
-      {% if not forloop.last %}
-        <div class="greyline"></div>
-      {% endif %}
-    {% endfor %}
-  </form>
-{% else %}
-  <span class="yellow">Без абонемента</span>
+    {% endwith %}
+  {% elif subscriptions|length > 1%}
+    <form class="subscription_select">
+      {% for sub in subscriptions %}
+        {% if sub.is_expiring %}
+          <span class="yellow">{{ sub.subscription.name }}</span>
+        {% else %}
+          {{ sub.subscription.name }}
+        {% endif %}
+        <br/>
+        <small>Доступно посещений: {{ sub.visits_left }} из
+          {{ sub.visits_on_by_time }}</small>
+        {% if not forloop.last %}
+          <div class="greyline"></div>
+        {% endif %}
+      {% endfor %}
+    </form>
+  {% else %}
+    <span class="yellow">Без абонемента</span>
 
-  {% if not client.deleted %}
-    {% ifhasperm 'client_subscription.sale' user %}
-      <br/>
-      {% if event %}
-        <a class="sell"
-           href="{% url 'crm:manager:client:new-subscription-with-event-by-date' client.id event.event_class.id event.date.year event.date.month event.date.day %}">
-          Продать</a>
+    {% if not client.deleted %}
+      {% ifhasperm 'client_subscription.sale' user %}
+        <br/>
+        {% if event %}
+          <a class="sell"
+             href="{% url 'crm:manager:client:new-subscription-with-event-by-date' client.id event.event_class.id event.date.year event.date.month event.date.day %}">
+            Продать</a>
+        {% else %}
+          <a class="sell"
+             href="{% url 'crm:manager:client:new-subscription' client.id %}">Продать</a>
+        {% endif %}
+      {% endifhasperm %}
+    {% endif %}
+  {% endif %}
+{% else %}
+  {% if active_sub|length == 1 %}
+    {% with active_sub.first as sub %}
+      {% if sub.is_expiring %}
+        <span class="yellow">{{ sub.subscription.name }}</span>
       {% else %}
-        <a class="sell"
-           href="{% url 'crm:manager:client:new-subscription' client.id %}">Продать</a>
+        {{ sub.subscription.name }}
       {% endif %}
-    {% endifhasperm %}
+      <br/>
+      <small>Доступно посещений: {{ sub.visits_left }} из
+        {{ sub.visits_on_by_time }}</small>
+    {% endwith %}
+  {% elif active_sub|length > 1 %}
+    <form class="subscription_select">
+      {% for sub in active_sub %}
+        {% if sub.is_expiring %}
+          <span class="yellow">{{ sub.subscription.name }}</span>
+        {% else %}
+          {{ sub.subscription.name }}
+        {% endif %}
+        <br/>
+        <small>Доступно посещений: {{ sub.visits_left }} из
+          {{ sub.visits_on_by_time }}</small>
+        {% if not forloop.last %}
+          <div class="greyline"></div>
+        {% endif %}
+      {% endfor %}
+    </form>
+  {% else %}
+    <span class="yellow">Без абонемента</span>
+
+    {% if not client.deleted %}
+      {% ifhasperm 'client_subscription.sale' user %}
+        <br/>
+        {% if event %}
+          <a class="sell"
+             href="{% url 'crm:manager:client:new-subscription-with-event-by-date' client.id event.event_class.id event.date.year event.date.month event.date.day %}">
+            Продать</a>
+        {% else %}
+          <a class="sell"
+             href="{% url 'crm:manager:client:new-subscription' client.id %}">Продать</a>
+        {% endif %}
+      {% endifhasperm %}
+    {% endif %}
   {% endif %}
 {% endif %}

--- a/crm/templates/crm/manager/event/detail.html
+++ b/crm/templates/crm/manager/event/detail.html
@@ -171,7 +171,7 @@
                         <td
                           class="d-none d-md-block">{% include 'crm/manager/_client_list_item_sub_last-date.html' %}</td>
                         <td class="d-none d-md-block">{% include 'crm/manager/_client_list_item_balance.html' %}</td>
-                        <td>{% include 'crm/manager/_client_list_item_buttons.html' with action=active_sub|length|yesno:"mark,new_subscription" %}</td>
+                        <td>{% include 'crm/manager/_client_list_item_buttons.html' %}</td>
                         <td>{% include 'crm/manager/_client_list_item_dropdown-menu.html' %}</td>
                       </tr>
                     {% endwith %}
@@ -198,7 +198,7 @@
                         <td
                           class="d-none d-md-block">{% include 'crm/manager/_client_list_item_sub_last-date.html' %}</td>
                         <td class="d-none d-md-block">{% include 'crm/manager/_client_list_item_balance.html' %}</td>
-                        <td>{% include 'crm/manager/_client_list_item_buttons.html' with action=active_sub|length|yesno:"mark,new_subscription" %}</td>
+                        <td>{% include 'crm/manager/_client_list_item_buttons.html' %}</td>
                         <td>{% include 'crm/manager/_client_list_item_dropdown-menu.html' %}</td>
                       </tr>
                     {% endwith %}


### PR DESCRIPTION
Don't use active subs for overpasted events, instead use historical
subsctions information

Fix subscription by date and coach template renderer