### PR TITLE
Transition cron to Celery and clean celery init

### DIFF
--- a/bot/api/cron/cron_client_events.py
+++ b/bot/api/cron/cron_client_events.py
@@ -10,8 +10,10 @@ from bot.api.messages import (
 )
 from bot.tasks import notify_clients_about_future_event
 from crm.models import Client, Company, INTERNAL_COMPANY, Manager
+from sportcrm.celery import app
 
 
+@app.task
 def receivables():
 
     for client in Client.objects.filter(balance__lt=0):
@@ -19,6 +21,7 @@ def receivables():
         ClientHaveNegativeBalance(client, personalized=False).send_message()
 
 
+@app.task
 def birthday():
     current_date = date.today()
     month = current_date.month
@@ -45,6 +48,7 @@ def birthday():
         ).send_message()
 
 
+@app.task
 def future_event():
     tomorrow = date.today() + timedelta(days=1)
     notify_clients_about_future_event(tomorrow)

--- a/bot/api/cron/manager_events.py
+++ b/bot/api/cron/manager_events.py
@@ -5,11 +5,13 @@ from django_multitenant.utils import set_current_tenant
 
 from bot.api.messages import ClosedEvent
 from crm.models import DayOfTheWeekClass, Event, Manager, ClientSubscriptions
+from sportcrm.celery import app
 
 DIFF_START = datetime.timedelta(minutes=39, seconds=59)
 DIFF_END = datetime.timedelta(minutes=30)
 
 
+@app.task
 def event_closing():
     p_now: pendulum.DateTime = pendulum.DateTime.now()
     p_start = p_now - DIFF_START

--- a/sportcrm/celery.py
+++ b/sportcrm/celery.py
@@ -1,14 +1,41 @@
 import os
 from celery import Celery
-import django
+from celery.schedules import crontab
 
 os.environ.setdefault('CELERY_CONFIG_MODULE', 'sportcrm.settings.celery_config')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'sportcrm.settings.gcp_test')
-django.setup()
 
 # set the default Django settings module for the 'celery' program.
-app = Celery('sportcrm', )
+app = Celery('sportcrm',
+             include=["bot.api.cron.manager_events",
+                      "bot.background_views"
+                      ])
 app.config_from_envvar('CELERY_CONFIG_MODULE')
 
-# Load task modules from all registered Django app configs.
-app.autodiscover_tasks()
+app.conf.beat_schedule = {
+
+    # - description: "daily birthday job"
+    "birthday": {
+        "task": "bot.background_views.birthday",
+        "schedule": crontab(minute="0", hour="3")
+    },
+
+    # - description: "daily birthday job"
+    "receivables": {
+        "task": "bot.background_views.receivables",
+        "schedule": crontab(minute="0", hour="8")
+    },
+
+    # - description: "daily future event job"
+    "future_event": {
+        "task": "bot.background_views.future_event",
+        "schedule": crontab(minute="0", hour="10")
+    },
+
+    # - description: "check every ten minutes for finished events"
+    "event_closing": {
+        "task": "bot.api.cron.manager_events.event_closing",
+        "schedule": crontab(minute="10", hour="*")
+    },
+}
+


### PR DESCRIPTION
Transition cron to Celery and clean celery init.
Time for cron in local timezone (set in base.py). Hours -5 to previous values.